### PR TITLE
API3-1

### DIFF
--- a/docs/contracts/api3-server-v1/oevauctionhouse.md
+++ b/docs/contracts/api3-server-v1/oevauctionhouse.md
@@ -139,6 +139,8 @@ The first of these is done by the "auction resolver" and the last two are done b
 - Normally, the auction resolver is expected to deliver the award within the award phase.
   In the case that the delivery is delayed due to networking or finality issues, it is preferable to not lock up the collateral of the bidder.
   For this, auction resolvers should use a sufficiently small `awardExpirationTimestamp` while calling `awardBid()`.
+  On the other hand, `awardExpirationTimestamp` should be large enough to ensure that `awardBid()` does not revert erroneously.
+  The recommended `awardExpirationTimestamp` value here is the start of the respective award phase plus `T` (the auction length).
 
 - It is assumed that the bidder has waited for sufficient finality before reporting their fulfillment.
   If the auction cop fails to confirm the bid payment due to a finality issue, it will contradict the fulfillment.


### PR DESCRIPTION
### API3-1 Seeker Can Avoid Paying Protocol or Collateral Fees if the Award Transaction Reverts

Mitigated.

If an auctioneer is sending its transactions through a public mempool, a searcher can use their award before the auctioneer transaction with the respective `awardBid()` call is confirmed. If this call succeeds later, the searcher will still have to report having paid the bid amount to avoid being slashed (which satisfies our requirements). On the other hand, if this call reverts later, the searcher will not be slashed for their bid, which indeed corresponds to being able to perform OEV updates without paying the respective bid amount.

The solution to this is for the auctioneer to only send award transactions that are guaranteed (within reasonable limits) to be confirmed. The [documentation](https://github.com/api3dao/contracts-qs/blob/main/docs/contracts/api3-server-v1/oevauctionhouse.md#auction-resolver-flow) emphasizes the importance of the auctioneer checking the bid expiration and the bidder balance, as these change outside the control of the auctioneer. Compared to these, in the current auction design, there is a deterministic way to choose a suitable `awardExpirationTimestamp` value.

We extended the docs to explain how auctioneers should choose `awardExpirationTimestamp`.